### PR TITLE
Line 39 - Remove Params

### DIFF
--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -36,7 +36,7 @@ else:
   
 #get comma separated list of zookeeper hosts from clusterHostInfo
 zookeeper_hosts = ",".join(config['clusterHostInfo']['zookeeper_hosts'])
-java64_home = params.config['hostLevelParams']['java_home']
+java64_home = config['hostLevelParams']['java_home']
 
 
 solr_user = config['configurations']['solr-env']['solr.user']


### PR DESCRIPTION
When I tried installing on Sandbox I kept getting error that "params" did not exist. I assumed something was wrong

Removed the "params." in from of "config" from line 39 and everything installed successfully
